### PR TITLE
Return type hint Frame[]

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -87,6 +87,9 @@ class Backtrace
         return $this;
     }
 
+    /**
+     * @return \Spatie\Backtrace\Frame[]
+     */
     public function frames(): array
     {
         $rawFrames = $this->getRawFrames();
@@ -130,6 +133,9 @@ class Backtrace
         return debug_backtrace($options, $limit);
     }
 
+    /**
+     * @return \Spatie\Backtrace\Frame[]
+     */
     protected function toFrameObjects(array $rawFrames): array
     {
         $currentFile = $this->throwable ? $this->throwable->getFile() : '';


### PR DESCRIPTION
Fantastic interface compared to the native backtrace! 
It would be even better if `Backtrace::frames()` would type hint `Frame[]` - that's the purpose of the PR.