### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1, 8.0, 7.4, 7.3]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow.
