### PR TITLE
Correct with object check

### DIFF
--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -145,7 +145,7 @@ class Backtrace
             $options = $options | DEBUG_BACKTRACE_IGNORE_ARGS;
         }
 
-        if ($this->withObject()) {
+        if ($this->withObject) {
             $options = $options | DEBUG_BACKTRACE_PROVIDE_OBJECT;
         }
 


### PR DESCRIPTION
It seems that the intention was to check whether `$this->withObject` property is truthy, but instead it would call the `$this->withObject()` method.
This both meant that the check would always evaluate `true` and that the property would be updated to `true` as well.