### PR TITLE
trimFilePaths feature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $backtrace = Spatie\Backtrace\Backtrace::create()->applicationPath(base_path());
 ```
 ### Removing the application path from the file name
 
-You can use `trimFilePaths` to remove the base path of your app from the file. This will only work if you use it in conjunction the `applicationPath` method re above. Here's an example using a Laravel specific function. This will ensure the Frame has the trimmedFile property set.
+You can use `trimFilePaths` to remove the base path of your app from the file. This will only work if you use it in conjunction the `applicationPath` method re above. Here's an example using a Laravel specific function. This will ensure the Frame has the trimmedFilePath property set.
 
 ```php
 $backtrace = Backtrace::create()->applicationPath(base_path())->trimFilePaths());

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ frame is an application frame, or a vendor frame. Here's an example using a Lara
 ```php
 $backtrace = Spatie\Backtrace\Backtrace::create()->applicationPath(base_path());
 ```
+### Removing the application path from the file name
+
+You can use `trimFilePaths` to remove the base path of your app from the file. This will only work if you use it in conjunction the `applicationPath` method re above. Here's an example using a Laravel specific function. This will ensure the Frame has the trimmedFile property set.
+
+```php
+$backtrace = Backtrace::create()->applicationPath(base_path())->trimFilePaths());
+```
 
 ### Getting a certain part of a trace
 

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -194,7 +194,7 @@ class Backtrace
             }
 
             if ($this->trimFilePaths && $this->applicationPath) {
-                $trimmedFile = str_replace($this->applicationPath, '', $currentFile);
+                $trimmedFilePath = str_replace($this->applicationPath, '', $currentFile);
             }
             $frame = new Frame(
                 $currentFile,
@@ -204,7 +204,7 @@ class Backtrace
                 $rawFrame['class'] ?? null,
                 $this->isApplicationFrame($currentFile),
                 $textSnippet,
-                $trimmedFile ?? null,
+                $trimmedFilePath ?? null,
             );
 
             $frames[] = $frame;

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -196,16 +196,15 @@ class Backtrace
             if ($this->trimFilePaths && $this->applicationPath) {
                 $trimmedFile = str_replace($this->applicationPath, '', $currentFile);
             }
-
             $frame = new Frame(
                 $currentFile,
-                $trimmedFile ?? null,
                 $currentLine,
                 $arguments,
                 $rawFrame['function'] ?? null,
                 $rawFrame['class'] ?? null,
                 $this->isApplicationFrame($currentFile),
-                $textSnippet
+                $textSnippet,
+                $trimmedFile ?? null,
             );
 
             $frames[] = $frame;
@@ -228,7 +227,6 @@ class Backtrace
 
         $frames[] = new Frame(
             $currentFile,
-            null,
             $currentLine,
             [],
             '[top]'

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -23,6 +23,9 @@ class Backtrace
     /** @var bool */
     protected $withObject = false;
 
+    /** @var bool */
+    protected $trimFilePaths = false;
+
     /** @var string|null */
     protected $applicationPath;
 
@@ -87,6 +90,13 @@ class Backtrace
     public function applicationPath(string $applicationPath): self
     {
         $this->applicationPath = rtrim($applicationPath, '/');
+
+        return $this;
+    }
+
+    public function trimFilePaths(): self
+    {
+        $this->trimFilePaths = true;
 
         return $this;
     }
@@ -183,8 +193,13 @@ class Backtrace
                 $currentLine -= 1;
             }
 
+            if ($this->trimFilePaths && $this->applicationPath) {
+                $trimmedFile = str_replace($this->applicationPath, '', $currentFile);
+            }
+
             $frame = new Frame(
                 $currentFile,
+                $trimmedFile ?? null,
                 $currentLine,
                 $arguments,
                 $rawFrame['function'] ?? null,
@@ -213,6 +228,7 @@ class Backtrace
 
         $frames[] = new Frame(
             $currentFile,
+            null,
             $currentLine,
             [],
             '[top]'

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -42,7 +42,7 @@ class Frame
         string $class = null,
         bool $isApplicationFrame = false,
         ?string $textSnippet = null,
-        ?string $trimmedFilePath = null,
+        ?string $trimmedFilePath = null
     ) {
         $this->file = $file;
 

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -36,13 +36,13 @@ class Frame
 
     public function __construct(
         string $file,
-        ?string $trimmedFile = null,
         int $lineNumber,
         ?array $arguments,
         string $method = null,
         string $class = null,
         bool $isApplicationFrame = false,
-        ?string $textSnippet = null
+        ?string $textSnippet = null,
+        ?string $trimmedFile = null,
     ) {
         $this->file = $file;
 

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -13,6 +13,9 @@ class Frame
     /** @var string */
     public $file;
 
+    /** @var string|null */
+    public $trimmedFile;
+
     /** @var int */
     public $lineNumber;
 
@@ -33,6 +36,7 @@ class Frame
 
     public function __construct(
         string $file,
+        ?string $trimmedFile = null,
         int $lineNumber,
         ?array $arguments,
         string $method = null,
@@ -41,6 +45,8 @@ class Frame
         ?string $textSnippet = null
     ) {
         $this->file = $file;
+
+        $this->trimmedFile = $trimmedFile;
 
         $this->lineNumber = $lineNumber;
 

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -14,7 +14,7 @@ class Frame
     public $file;
 
     /** @var string|null */
-    public $trimmedFile;
+    public $trimmedFilePath;
 
     /** @var int */
     public $lineNumber;
@@ -42,11 +42,11 @@ class Frame
         string $class = null,
         bool $isApplicationFrame = false,
         ?string $textSnippet = null,
-        ?string $trimmedFile = null,
+        ?string $trimmedFilePath = null,
     ) {
         $this->file = $file;
 
-        $this->trimmedFile = $trimmedFile;
+        $this->trimmedFilePath = $trimmedFilePath;
 
         $this->lineNumber = $lineNumber;
 

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -306,7 +306,7 @@ EOT,
     {
         $this->assertEquals(DIRECTORY_SEPARATOR.basename(self::class).'.php', Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames()[0]->trimmedFile);
     }
-    
+
     /** @test */
     public function it_does_not_trim_file_path_if_no_application_path_set()
     {

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -307,13 +307,13 @@ EOT,
     {
         $className = (new ReflectionClass(self::class))->getShortName();
 
-        $this->assertEquals(DIRECTORY_SEPARATOR.$className.'.php', Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames()[0]->trimmedFile);
+        $this->assertEquals(DIRECTORY_SEPARATOR.$className.'.php', Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames()[0]->trimmedFilePath);
     }
 
     /** @test */
     public function it_does_not_trim_file_path_if_no_application_path_set()
     {
-        $this->assertNull(Backtrace::create()->trimFilePaths()->frames()[0]->trimmedFile);
+        $this->assertNull(Backtrace::create()->trimFilePaths()->frames()[0]->trimmedFilePath);
     }
 
 }

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -4,6 +4,7 @@ namespace Spatie\Backtrace\Tests;
 
 use DateTime;
 use PHPUnit\Framework\TestSuite;
+use ReflectionClass;
 use Spatie\Backtrace\Arguments\ArgumentReducers;
 use Spatie\Backtrace\Backtrace;
 use Spatie\Backtrace\Frame;
@@ -304,7 +305,9 @@ EOT,
     /** @test */
     public function it_trims_file_path_if_application_path_set()
     {
-        $this->assertEquals(DIRECTORY_SEPARATOR.basename(self::class).'.php', Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames()[0]->trimmedFile);
+        $className = (new ReflectionClass(self::class))->getShortName();
+
+        $this->assertEquals(DIRECTORY_SEPARATOR.$className.'.php', Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames()[0]->trimmedFile);
     }
 
     /** @test */

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -300,4 +300,16 @@ EOT,
     {
         $this->assertEquals(0, Backtrace::create()->firstApplicationFrameIndex());
     }
+
+    /** @test */
+    public function it_trims_file_path_if_application_path_set()
+    {
+        $this->assertEquals(DIRECTORY_SEPARATOR.basename(self::class).'.php', Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames()[0]->trimmedFile);
+    }
+    /** @test */
+    public function it_does_not_trim_file_path_if_no_application_path_set()
+    {
+        $this->assertNull(Backtrace::create()->trimFilePaths()->frames()[0]->trimmedFile);
+    }
+
 }

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -306,6 +306,7 @@ EOT,
     {
         $this->assertEquals(DIRECTORY_SEPARATOR.basename(self::class).'.php', Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames()[0]->trimmedFile);
     }
+    
     /** @test */
     public function it_does_not_trim_file_path_if_no_application_path_set()
     {


### PR DESCRIPTION
I'm using this package to display something like :

```select * from `foo` limit 100; 0.35ms [edit in /var/www/vhosts/jack/app/Http/Controllers/FooController.php:15``` 

I'm having to trim the file property to remove the application path, ie in the above case `/var/www/vhosts/jack`  

I thought it would be worth trying to add it to the package itself, so that you could do something along the lines of: ```Backtrace::create()->applicationPath(__DIR__)->trimFilePaths()->frames())``` - then you can access the trimmedFile property to access it. and if no application path is provided, it will just be null. 

I wanted to do this directly on the file property, but it was being used [here](https://github.com/spatie/backtrace/blob/main/src/Frame.php#L92) - hence why I added a new property.   

There might be a better way - so open to suggestions,  If you don't think it's worth it no problem.