### PR TITLE
Add PHP 8.4 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.3, 7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,11 @@
 {
     "name": "spatie/backtrace",
     "description": "A better backtrace",
+    "license": "MIT",
     "keywords": [
         "spatie",
         "backtrace"
     ],
-    "homepage": "https://github.com/spatie/backtrace",
-    "license": "MIT",
     "authors": [
         {
             "name": "Freek Van de Herten",
@@ -15,16 +14,29 @@
             "role": "Developer"
         }
     ],
+    "homepage": "https://github.com/spatie/backtrace",
+    "funding": [
+        {
+            "type": "github",
+            "url": "https://github.com/sponsors/spatie"
+        },
+        {
+            "type": "other",
+            "url": "https://spatie.be/open-source/support-us"
+        }
+    ],
     "require": {
-        "php": "^7.3|^8.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "ext-json": "*",
+        "laravel/serializable-closure": "^1.3 || ^2.0",
         "phpunit/phpunit": "^9.3",
-        "laravel/serializable-closure": "^1.3",
         "spatie/phpunit-snapshot-assertions": "^4.2",
         "symfony/var-dumper": "^5.1"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "Spatie\\Backtrace\\": "src"
@@ -35,25 +47,13 @@
             "Spatie\\Backtrace\\Tests\\": "tests"
         }
     },
-    "scripts": {
-        "psalm": "vendor/bin/psalm",
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
-        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes"
-    },
     "config": {
         "sort-packages": true
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
-    "funding": [
-        {
-            "type": "github",
-            "url": "https://github.com/sponsors/spatie"
-        },
-        {
-            "type": "other",
-            "url": "https://spatie.be/open-source/support-us"
-        }
-    ]
+    "scripts": {
+        "format": "vendor/bin/php-cs-fixer fix --allow-risky=yes",
+        "psalm": "vendor/bin/psalm",
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
     "require-dev": {
         "ext-json": "*",
         "laravel/serializable-closure": "^1.3 || ^2.0",
-        "phpunit/phpunit": "^9.3",
-        "spatie/phpunit-snapshot-assertions": "^4.2",
-        "symfony/var-dumper": "^5.1"
+        "phpunit/phpunit": "^9.3 || ^11.4.3",
+        "spatie/phpunit-snapshot-assertions": "^4.2 || ^5.1.6",
+        "symfony/var-dumper": "^5.1 || ^6.0 || ^7.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -149,7 +149,7 @@ class Backtrace
             return $this->throwable->getTrace();
         }
 
-        $options = null;
+        $options = DEBUG_BACKTRACE_PROVIDE_OBJECT;
 
         if (! $this->withArguments) {
             $options = $options | DEBUG_BACKTRACE_IGNORE_ARGS;

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -38,8 +38,8 @@ class Frame
         string $file,
         int $lineNumber,
         ?array $arguments,
-        string $method = null,
-        string $class = null,
+        ?string $method = null,
+        ?string $class = null,
         bool $isApplicationFrame = false,
         ?string $textSnippet = null,
         ?string $trimmedFilePath = null

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -243,7 +243,7 @@ class BacktraceTest extends TestCase
 
         if (version_compare(PHP_VERSION, '8.4', '>=')) {
             $this->assertEquals(
-            <<<'EOT'
+                <<<'EOT'
 {closure:laravel-serializable-closure://function () {
             throw new \Exception('This is a test exception from a serialized closure');
         }:2}
@@ -296,7 +296,7 @@ EOT,
 
         if (version_compare(PHP_VERSION, '8.4', '>=')) {
             $this->assertEquals(
-            <<<'EOT'
+                <<<'EOT'
 {closure:laravel-serializable-closure://function () {
             self::throw();
         }:2}

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -240,7 +240,20 @@ class BacktraceTest extends TestCase
         $firstFrame = $frames[0];
 
         $this->assertEquals(2, $firstFrame->lineNumber);
-        $this->assertEquals('{closure}', $firstFrame->method);
+
+        if (version_compare(PHP_VERSION, '8.4', '>=')) {
+            $this->assertEquals(
+            <<<'EOT'
+{closure:laravel-serializable-closure://function () {
+            throw new \Exception('This is a test exception from a serialized closure');
+        }:2}
+EOT,
+                $firstFrame->method
+            );
+        } else {
+            $this->assertEquals('{closure}', $firstFrame->method);
+        }
+
         $this->assertEquals(LaravelSerializableClosureThrow::class, $firstFrame->class);
         $this->assertTrue($firstFrame->applicationFrame);
 
@@ -280,7 +293,20 @@ EOT,
         $secondFrame = $frames[1];
 
         $this->assertEquals(2, $secondFrame->lineNumber);
-        $this->assertEquals('{closure}', $secondFrame->method);
+
+        if (version_compare(PHP_VERSION, '8.4', '>=')) {
+            $this->assertEquals(
+            <<<'EOT'
+{closure:laravel-serializable-closure://function () {
+            self::throw();
+        }:2}
+EOT,
+                $secondFrame->method
+            );
+        } else {
+            $this->assertEquals('{closure}', $secondFrame->method);
+        }
+
         $this->assertEquals(LaravelSerializableClosureCallThrow::class, $secondFrame->class);
         $this->assertTrue($secondFrame->applicationFrame);
 

--- a/tests/ReduceArgumentsTest.php
+++ b/tests/ReduceArgumentsTest.php
@@ -61,7 +61,7 @@ class ReduceArgumentsTest extends TestCase
         );
     }
 
-    public function reduceableFramesDataSet()
+    public static function reduceableFramesDataSet()
     {
         yield 'without arguments' => [
             TraceArguments::create()->withoutArguments(),
@@ -566,7 +566,7 @@ class ReduceArgumentsTest extends TestCase
         $this->assertEquals($expected, $argument->toArray());
     }
 
-    public function providedArgumentsDataSet()
+    public static function providedArgumentsDataSet()
     {
         yield 'base' => [
             ProvidedArgumentFactory::create('string')


### PR DESCRIPTION
This pull request includes several updates to improve compatibility, enhance functionality, and fix issues in the project. The most important changes include adding support for new PHP versions, updating dependencies, and improving test coverage.

### Compatibility and Dependency Updates:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L12-R12): Added PHP versions 8.3 and 8.4 to the test matrix to ensure compatibility with the latest PHP releases.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R4-L9): Updated the `require` and `require-dev` sections to support a wider range of PHP versions and package versions, ensuring compatibility with newer releases. Also moved the `funding` `homepage` and `license` fields for better organization. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R4-L9) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R17-R39) [[3]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L38-L58)

### Code Improvements:

* [`src/Backtrace.php`](diffhunk://#diff-0dd5ce49449ebb8498e6b7f7e59ea76250550595b5adca885b7b116ac6e4d3ffL152-R152): Changed the `$options` variable to use `DEBUG_BACKTRACE_PROVIDE_OBJECT` as parameter doesn't accept null and throws deprecation warning on PHP 8.4 [PHP Docs](https://www.php.net/manual/en/function.debug-backtrace.php).
* [`src/Frame.php`](diffhunk://#diff-88ae6ee170009a95e7550d984c5fcbc3917bdb476a875a931336ac06a667af21L41-R42): Made the `method` and `class` parameters nullable in the constructor for better flexibility and fixing of deprecation warnings.

### Test Enhancements:

* [`tests/BacktraceTest.php`](diffhunk://#diff-88471875bd92cd8813868fe85f71e96a5ccda881368d79f4f7a4710747c5b937R243-R256): Added conditional assertions to handle differences in PHP versions for methods involving closures (See [PHP 8.4 changes](https://github.com/php/php-src/pull/13550)), ensuring tests pass across different PHP versions. [[1]](diffhunk://#diff-88471875bd92cd8813868fe85f71e96a5ccda881368d79f4f7a4710747c5b937R243-R256) [[2]](diffhunk://#diff-88471875bd92cd8813868fe85f71e96a5ccda881368d79f4f7a4710747c5b937R296-R309)
* [`tests/ReduceArgumentsTest.php`](diffhunk://#diff-652a8fc512ee2920f4cf76d34d555da08f44eff565d5b743d50181e14c9fa602L64-R64): Changed test data providers to be static methods, improving test organization and consistency. [[1]](diffhunk://#diff-652a8fc512ee2920f4cf76d34d555da08f44eff565d5b743d50181e14c9fa602L64-R64) [[2]](diffhunk://#diff-652a8fc512ee2920f4cf76d34d555da08f44eff565d5b743d50181e14c9fa602L569-R569)