### PR TITLE
Add object property to frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,17 @@ A `Spatie\Backtrace\Frame` has these properties:
 - `arguments`: the arguments used for this frame. Will be `null` if `withArguments` was not used.
 - `class`: the class name for this frame. Will be `null` if the frame concerns a function.
 - `method`: the method used in this frame
+- `object`: the object when the frame is in an object context (method call, closure bound to object, arrow function which captured `$this`, etc.). Will be `null` if `withObject` was not used.
 - `applicationFrame`: contains `true` is this frame belongs to your application, and `false` if it belongs to a file in
   the vendor directory
 
-### Collecting arguments
+### Collecting arguments and objects
 
-For performance reasons, the frames of the back trace will not contain the arguments of the called functions. If you
-want to add those use the `withArguments` method.
+For performance reasons, the frames of the back trace will not contain the arguments of the called functions and the
+object. If you want to add those, use the `withArguments` and `withObject` methods.
 
 ```php
-$backtrace = Spatie\Backtrace\Backtrace::create()->withArguments();
+$backtrace = Spatie\Backtrace\Backtrace::create()->withArguments()->withObject();
 ```
 
 #### Reducing arguments

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -149,12 +149,15 @@ class Backtrace
             return $this->throwable->getTrace();
         }
 
-        $options = 0;
+        // Omit arguments and object
+        $options = DEBUG_BACKTRACE_IGNORE_ARGS;
 
-        if (! $this->withArguments) {
-            $options = $options | DEBUG_BACKTRACE_IGNORE_ARGS;
+        // Populate arguments
+        if ($this->withArguments) {
+            $options = 0;
         }
 
+        // Populate object
         if ($this->withObject) {
             $options = $options | DEBUG_BACKTRACE_PROVIDE_OBJECT;
         }

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -149,7 +149,7 @@ class Backtrace
             return $this->throwable->getTrace();
         }
 
-        $options = DEBUG_BACKTRACE_PROVIDE_OBJECT;
+        $options = 0;
 
         if (! $this->withArguments) {
             $options = $options | DEBUG_BACKTRACE_IGNORE_ARGS;

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -80,9 +80,9 @@ class Backtrace
         return $this;
     }
 
-    public function withObject(): self
+    public function withObject(bool $withObject = true): self
     {
-        $this->withObject = true;
+        $this->withObject = $withObject;
 
         return $this;
     }

--- a/src/Backtrace.php
+++ b/src/Backtrace.php
@@ -202,6 +202,7 @@ class Backtrace
                 $arguments,
                 $rawFrame['function'] ?? null,
                 $rawFrame['class'] ?? null,
+                $rawFrame['object'] ?? null,
                 $this->isApplicationFrame($currentFile),
                 $textSnippet,
                 $trimmedFilePath ?? null,

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -31,6 +31,9 @@ class Frame
     /** @var string|null */
     public $class;
 
+    /** @var object|null */
+    public $object;
+
     /** @var string|null */
     protected $textSnippet;
 
@@ -40,6 +43,7 @@ class Frame
         ?array $arguments,
         ?string $method = null,
         ?string $class = null,
+        ?object $object = null,
         bool $isApplicationFrame = false,
         ?string $textSnippet = null,
         ?string $trimmedFilePath = null
@@ -55,6 +59,8 @@ class Frame
         $this->method = $method;
 
         $this->class = $class;
+
+        $this->object = $object;
 
         $this->applicationFrame = $isApplicationFrame;
 

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -80,6 +80,90 @@ class BacktraceTest extends TestCase
     }
 
     /** @test */
+    public function it_can_get_add_the_object()
+    {
+        $firstFrame = Backtrace::create()->frames()[0];
+
+        $this->assertNull($firstFrame->object);
+
+        $firstFrame = Backtrace::create()
+            ->withObject()
+            ->frames()[0];
+
+        $this->assertIsObject($firstFrame->object);
+    }
+
+    /** @test */
+    public function it_can_disable_the_use_of_the_object_with_a_backtrace()
+    {
+        /** @return \Spatie\Backtrace\Frame[] */
+        function createBackTraceWithoutObject(): array
+        {
+            return Backtrace::create()
+                ->withObject(false)
+                ->frames();
+        }
+
+        $frames = createBackTraceWithoutObject();
+
+        $this->assertNull($frames[1]->object);
+    }
+
+    /** @test */
+    public function it_can_disable_the_use_of_arguments_and_enable_the_use_of_the_object_with_a_backtrace()
+    {
+        /** @return \Spatie\Backtrace\Frame[] */
+        function createBackTraceWithoutArgumentsAndWithObject(string $string): array
+        {
+            return Backtrace::create()
+                ->withArguments(false)
+                ->withObject()
+                ->frames();
+        }
+
+        $frames = createBackTraceWithoutArgumentsAndWithObject('Hello World');
+
+        $this->assertNull($frames[1]->arguments);
+        $this->assertIsObject($frames[1]->object);
+    }
+
+    /** @test */
+    public function it_can_enable_the_use_of_arguments_and_disable_the_use_of_the_object_with_a_backtrace()
+    {
+        /** @return \Spatie\Backtrace\Frame[] */
+        function createBackTraceWithArgumentsAndWithoutObject(string $string): array
+        {
+            return Backtrace::create()
+                ->withArguments()
+                ->withObject(false)
+                ->frames();
+        }
+
+        $frames = createBackTraceWithArgumentsAndWithoutObject('Hello World');
+
+        $this->assertIsArray($frames[1]->arguments);
+        $this->assertNull($frames[1]->object);
+    }
+
+    /** @test */
+    public function it_can_enable_the_use_of_arguments_and_the_object_with_a_backtrace()
+    {
+        /** @return \Spatie\Backtrace\Frame[] */
+        function createBackTraceWithArgumentsAndObject(string $string): array
+        {
+            return Backtrace::create()
+                ->withArguments()
+                ->withObject()
+                ->frames();
+        }
+
+        $frames = createBackTraceWithArgumentsAndObject('Hello World');
+
+        $this->assertIsArray($frames[1]->arguments);
+        $this->assertIsObject($frames[1]->object);
+    }
+
+    /** @test */
     public function it_can_get_add_the_arguments_reduced()
     {
         function createBackTrace(string $test, bool $withArguments): Frame


### PR DESCRIPTION
`Backtrace` currently has `withObject()` which includes the frame's object in the backtrace. However, this object can't be accessed because it's not stored in `Frame`. By adding the `object` property to `Frame`, it is now accessible when `withObject()` is called.

An important fix which resulted from writing the tests for this change is [using the correct backtrace flags in `getRawFrames()` when `withObject` is false](https://github.com/spatie/backtrace/compare/main...jivanf:backtrace:add-object-property-to-frame?expand=1#diff-0dd5ce49449ebb8498e6b7f7e59ea76250550595b5adca885b7b116ac6e4d3ffR152). Since the initial value of `$options` was `DEBUG_BACKTRACE_PROVIDE_OBJECT` and `$options` is only changed when `withObject` is true, having `withObject` as false didn't change `$options`, which caused the object to be included in the backtrace.

Finally, a boolean parameter was added to `withObject()` to align its signature with `withArguments()` and the README was updated to document `withObject()`.

---

On a side note, I'd suggest mentioning in the README that throwable backtraces will only include arguments if the `zend.exception_ignore_args` INI option is set to 0 *before* the exception is thrown, while objects will never be included (this is why I didn't write `withObject` tests for throwable backtraces). This is mentioned [here](https://www.php.net/manual/en/throwable.gettrace.php#129087). Something like:

>Note that when getting a backtrace for a throwable, `withArguments` only has an effect if the `zend.exception_ignore_args` INI option is disabled (set to 0) *before* the exception is thrown, while `withObject` never has an effect. [More information](https://www.php.net/manual/en/throwable.gettrace.php#129087).

I didn't add this to the PR because it's unrelated to the other changes. Let me know what you think :slightly_smiling_face: 