### PR TITLE
Add test for enabling arguments with a throwable

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,10 @@ Here's how you can get a backtrace for a throwable.
 $frames = Spatie\Backtrace\Backtrace::createForThrowable($throwable)
 ```
 
-Because we will use the backtrace that is already available the throwable, the frames will always contain the arguments used.
+Because we will use the backtrace that is already available in the throwable, the frames will contain the arguments used
+in the backtrace as long as the `zend.exception_ignore_args` INI option is set *before* the throwable is thrown.
+On the other hand, objects will never be included in the backtrace. 
+[More information](https://www.php.net/manual/en/throwable.gettrace.php#129087).
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ $frames = Spatie\Backtrace\Backtrace::createForThrowable($throwable)
 ```
 
 Because we will use the backtrace that is already available in the throwable, the frames will contain the arguments used
-in the backtrace as long as the `zend.exception_ignore_args` INI option is set *before* the throwable is thrown.
-On the other hand, objects will never be included in the backtrace. 
+in the backtrace as long as the `zend.exception_ignore_args` INI option is disabled (set to `0`) *before* the throwable
+is thrown. On the other hand, objects will never be included in the backtrace. 
 [More information](https://www.php.net/manual/en/throwable.gettrace.php#129087).
 
 ## Testing

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -33,7 +33,7 @@ class BacktraceTest extends TestCase
     }
 
     /** @test */
-    public function it_can_get_add_the_arguments()
+    public function it_can_get_add_the_arguments_with_a_backtrace()
     {
         /** @var \Spatie\Backtrace\Frame $firstFrame */
         $firstFrame = Backtrace::create()->frames()[0];
@@ -46,6 +46,22 @@ class BacktraceTest extends TestCase
             ->frames()[0];
 
         $this->assertIsArray($firstFrame->arguments);
+    }
+
+    /** @test */
+    public function it_can_get_add_the_arguments_with_a_throwable()
+    {
+        $exception = TraceArguments::create()->exception(
+            'Hello World',
+            new DateTime(),
+        );
+
+        $this->assertIsArray(
+            Backtrace::createForThrowable($exception)
+                ->withArguments()
+                ->frames()[1]
+                ->arguments
+        );
     }
 
     /** @test */
@@ -74,37 +90,6 @@ class BacktraceTest extends TestCase
         $this->assertNull(
             Backtrace::createForThrowable($exception)
                 ->withArguments(false)
-                ->frames()[1]
-                ->arguments
-        );
-    }
-
-    /** @test */
-    public function it_can_enable_the_use_of_arguments_with_a_backtrace()
-    {
-        function createBackTraceWithArguments(string $string): array
-        {
-            return Backtrace::create()
-                ->withArguments()
-                ->frames();
-        }
-
-        $frames = createBackTraceWithArguments('Hello World');
-
-        $this->assertIsArray($frames[1]->arguments);
-    }
-
-    /** @test */
-    public function it_can_enable_the_use_of_arguments_with_a_throwable()
-    {
-        $exception = TraceArguments::create()->exception(
-            'Hello World',
-            new DateTime(),
-        );
-
-        $this->assertIsArray(
-            Backtrace::createForThrowable($exception)
-                ->withArguments()
                 ->frames()[1]
                 ->arguments
         );

--- a/tests/BacktraceTest.php
+++ b/tests/BacktraceTest.php
@@ -80,6 +80,37 @@ class BacktraceTest extends TestCase
     }
 
     /** @test */
+    public function it_can_enable_the_use_of_arguments_with_a_backtrace()
+    {
+        function createBackTraceWithArguments(string $string): array
+        {
+            return Backtrace::create()
+                ->withArguments()
+                ->frames();
+        }
+
+        $frames = createBackTraceWithArguments('Hello World');
+
+        $this->assertIsArray($frames[1]->arguments);
+    }
+
+    /** @test */
+    public function it_can_enable_the_use_of_arguments_with_a_throwable()
+    {
+        $exception = TraceArguments::create()->exception(
+            'Hello World',
+            new DateTime(),
+        );
+
+        $this->assertIsArray(
+            Backtrace::createForThrowable($exception)
+                ->withArguments()
+                ->frames()[1]
+                ->arguments
+        );
+    }
+
+    /** @test */
     public function it_can_get_add_the_arguments_reduced()
     {
         function createBackTrace(string $test, bool $withArguments): Frame

--- a/tests/TestClasses/TraceArguments.php
+++ b/tests/TestClasses/TraceArguments.php
@@ -150,7 +150,15 @@ class TraceArguments
         string $string,
         DateTime $dateTime
     ): Exception {
-        return new Exception('Some exception');
+        $ignoreArgsOriginalValue = ini_get('zend.exception_ignore_args');
+
+        ini_set('zend.exception_ignore_args', false);
+
+        $exception = new Exception('Some exception');
+
+        ini_set('zend.exception_ignore_args', $ignoreArgsOriginalValue);
+
+        return $exception;
     }
 
     protected function getTraceFrames(): array


### PR DESCRIPTION
Currently, disabling arguments is tested for both the backtrace and the throwable, but enabling arguments is tested only for the backtrace. This PR adds the missing test for the throwable, which requires disabling the `zend.exception_ignore_args` INI option when the test exception is created.

I also took the opportunity to update the README because some developers might be unaware of this option. If the INI option is not disabled before an exception is thrown, they won't see any arguments in backtraces created for throwables.