### PR TITLE
Fix `getCodeSnippetProvider` when `file` is not in `open_basedir`

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -101,7 +101,7 @@ class Frame
             return new LaravelSerializableClosureSnippetProvider($this->textSnippet);
         }
 
-        if (file_exists($this->file)) {
+        if (@file_exists($this->file)) {
             return new FileSnippetProvider($this->file);
         }
 


### PR DESCRIPTION
Was trying to use spate/ignition in an app with a tight `open_basedir` value set, but was seeing this error on the page which prevented the screen from loading:
```
<script>
    window.data = <br />
<b>Fatal error</b>:  Uncaught ErrorException: file_exists(): open_basedir restriction in effect. File(/Users/tadhg/.composer/vendor/laravel/valet/server.php) is not within the allowed path(s): (/Users/tadhg/Desktop/Programming/Nameless:/var/tmp/:/proc/stat) in /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/backtrace/src/Frame.php:104
Stack trace:
#0 [internal function]: Spatie\Ignition\Ignition-&gt;renderError(2, 'file_exists(): ...', '/Users/tadhg/De...', 104)
#1 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/backtrace/src/Frame.php(104): file_exists('/Users/tadhg/.c...')
#2 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/backtrace/src/Frame.php(75): Spatie\Backtrace\Frame-&gt;getCodeSnippetProvider()
#3 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/flare-client-php/src/Frame.php(27): Spatie\Backtrace\Frame-&gt;getSnippet(30)
#4 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/flare-client-php/src/Report.php(350): Spatie\FlareClient\Frame-&gt;toArray()
#5 [internal function]: Spatie\FlareClient\Report-&gt;Spatie\FlareClient\{closure}(Object(Spatie\Backtrace\Frame))
#6 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/flare-client-php/src/Report.php(349): array_map(Object(Closure), Array)
#7 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/flare-client-php/src/Report.php(403): Spatie\FlareClient\Report-&gt;stracktraceAsArray()
#8 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/ignition/src/ErrorPage/ErrorPageViewModel.php(90): Spatie\FlareClient\Report-&gt;toArray()
#9 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/ignition/resources/views/errorPage.php(43): Spatie\Ignition\ErrorPage\ErrorPageViewModel-&gt;report()
#10 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/ignition/src/ErrorPage/Renderer.php(18): include('/Users/tadhg/De...')
#11 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/ignition/src/Ignition.php(321): Spatie\Ignition\ErrorPage\Renderer-&gt;render(Array, '/Users/tadhg/De...')
#12 /Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/ignition/src/Ignition.php(291): Spatie\Ignition\Ignition-&gt;renderException(Object(ErrorException), Object(Spatie\FlareClient\Report))
#13 [internal function]: Spatie\Ignition\Ignition-&gt;handleException(Object(ErrorException))
#14 {main}
  thrown in <b>/Users/tadhg/Desktop/Programming/Nameless/vendor/spatie/backtrace/src/Frame.php</b> on line <b>104</b><br />
```